### PR TITLE
Support compiling with web-sys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ env_logger = { version = "0.7", default-features = false }
 [features]
 default = ["fs"]
 fs = ["memmap2"] # allows local filesystem interactions
+web-sys = ["uuid/wasm-bindgen"]


### PR DESCRIPTION
This is 1/2 of the change needed for https://github.com/RazrFalcon/resvg/issues/229. Somebody targeting web-sys can depend on fontdb with `default-features = false, features=["web-sys"]`