### PR TITLE
Update memmap2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["text-processing"]
 
 [dependencies]
 log = "0.4"
-memmap2 = { version = "0.1", optional = true }
+memmap2 = { version = "0.2", optional = true }
 ttf-parser = "0.9"
 
 [dev-dependencies]


### PR DESCRIPTION
`usvg` uses the newer `memmap2`, so an application depending on both winds up increasing build time and size slightly by including two versions. I can built `fontdb` and run the example with this change, but otherwise, I haven't tested it end-to-end. Let me know if I should.