### PR TITLE
Prefer name ID 16 over 1 if available for family

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,7 +609,9 @@ fn parse_face_info(
 ) -> Result<FaceInfo, LoadError> {
     let face = ttf_parser::Face::from_slice(data, index).map_err(|_| LoadError::MalformedFont)?;
 
-    let family = parse_name(ttf_parser::name_id::FAMILY, &face).ok_or(LoadError::UnnamedFont)?;
+    let family = parse_name(ttf_parser::name_id::TYPOGRAPHIC_FAMILY, &face)
+        .or_else(|| parse_name(ttf_parser::name_id::FAMILY, &face))
+        .ok_or(LoadError::UnnamedFont)?;
 
     let post_script_name = parse_name(ttf_parser::name_id::POST_SCRIPT_NAME, &face)
         .ok_or(LoadError::UnnamedFont)?;


### PR DESCRIPTION
I was wondering why some fonts in my scan had unexpected family names (e.g. `DejaVu Sans Light` instead of `DejaVu Sans`)... according to the [Name ID docs](https://docs.microsoft.com/en-us/typography/opentype/spec/name), ID=1 is the "font family name" with the additional requirement that it should be shared by at most four fonts. ID=16 is essentially the same name but without this restriction, though it may be absent(?) hence we use 1 if 16 is not available.