### PR TITLE
Remove memmap2 dependency on wasm32 targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ ttf-parser = "0.12.1"
 env_logger = { version = "0.8", default-features = false }
 
 [features]
-default = ["fs"]
-fs = ["memmap2"] # allows local filesystem interactions
+default = ["fs", "memmap"]
+fs = [] # allows local filesystem interactions
+memmap = ["fs", "memmap2"] # allows font files memory mapping, greatly improves performance


### PR DESCRIPTION
I tried to get usvg to run on top of wasmtime with filesystem emulation.

This patch conditionally disables the memmap2 dependency on wasm32 targets and enables a fallback code path that simply uses `read_to_end`. With this patch, fontdb successfully renders text to paths on wasmtime.

Please note that this is the first rust I've written ever, so please sanity-check this before merging.