### PR TITLE
Add the ability to share font data with the application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
-- The `Source` enum has two new variants `SharedFile` and `SharedBinary`, used them
-  using unsafe persistent memory mappings.
+- The `Source` enum has a new variant `SharedFile`, used for unsafe persistent
+  memory mappings.
+- `FaceInfo` stores `Source` directly now, not anymore in an `Arc`. Instead `Source::Binary`
+  now stores an `Arc` of the data.
 
 ## [0.6.2] - 2021-09-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- The `Source` enum has two new variants `SharedFile` and `SharedBinary`, used them
+  using unsafe persistent memory mappings.
 
 ## [0.6.2] - 2021-09-04
 ### Fixed

--- a/examples/find-system-font.rs
+++ b/examples/find-system-font.rs
@@ -23,7 +23,7 @@ fn main() {
     match db.query(&query) {
         Some(id) => {
             let (src, index) = db.face_source(id).unwrap();
-            if let fontdb::Source::File(ref path) = &*src {
+            if let fontdb::Source::File(ref path) = &src {
                 println!("Font '{}':{} found in {}ms.", path.display(), index,
                          now.elapsed().as_micros() as f64 / 1000.0);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,8 +61,7 @@ then you can use the unsafe [`Database::make_shared_face_data`] function.
 #![warn(missing_debug_implementations)]
 #![warn(missing_copy_implementations)]
 
-#[cfg(feature = "fs")] use std::path::Path;
-use std::path::PathBuf;
+#[cfg(feature = "fs")] use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use log::warn;


### PR DESCRIPTION
This adds two unsafe functions that will convert font data to an
Arc<dyn AsRef<[u8]> + Send + Sync> that's returned to the application.

If the face is backed by a file on disk, then it will be mmapped.

Fixes #18