### PR TITLE
Use fontconfig-parser for get system font directories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,14 @@ log = "0.4"
 memmap2 = { version = "0.5", optional = true }
 ttf-parser = "0.12.1"
 
+[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))'.dependencies]
+fontconfig-parser = { version = "0.5", optional = true }
+
 [dev-dependencies]
 env_logger = { version = "0.8", default-features = false }
 
 [features]
 default = ["fs", "memmap"]
+fontconfig = ["fontconfig-parser", "fs"]
 fs = [] # allows local filesystem interactions
 memmap = ["fs", "memmap2"] # allows font files memory mapping, greatly improves performance

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,6 +283,23 @@ impl Database {
         // Linux.
         #[cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))]
         {
+            #[cfg(feature = "fontconfig")]
+            {
+                let mut fontconfig = fontconfig_parser::FontConfig::default();
+                match fontconfig.merge_config("/etc/fonts/fonts.conf") {
+                    Ok(_) => {
+                        for dir in fontconfig.dirs {
+                            self.load_fonts_dir(dir.path);
+                        }
+
+                        return;
+                    }
+                    Err(err) => {
+                        log::error!("fontconfig parse error: {}", err);
+                    }
+                }
+            }
+
             self.load_fonts_dir("/usr/share/fonts/");
             self.load_fonts_dir("/usr/local/share/fonts/");
 


### PR DESCRIPTION
Fix #20

* Add new feature `fontconfig`
* Get font directories from `FontConfig` then load it
* If parsing failed, use current loading code