### PR TITLE
no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,11 @@ categories = ["text-processing"]
 [dependencies]
 log = "0.4"
 memmap2 = { version = "0.5", optional = true }
-ttf-parser = "0.17"
+
+[dependencies.ttf-parser]
+version = "0.17"
+default-features = false
+features = ["opentype-layout", "apple-layout", "variable-fonts", "glyph-names"]
 
 [target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))'.dependencies]
 fontconfig-parser = { version = "0.5", optional = true, default-features = false }
@@ -23,7 +27,8 @@ fontconfig-parser = { version = "0.5", optional = true, default-features = false
 env_logger = { version = "0.9", default-features = false }
 
 [features]
-default = ["fs", "memmap"]
+default = ["fs", "memmap", "std"]
 fontconfig = ["fontconfig-parser", "fs"]
-fs = [] # allows local filesystem interactions
+fs = ["std"] # allows local filesystem interactions
 memmap = ["fs", "memmap2"] # allows font files memory mapping, greatly improves performance
+std = ["ttf-parser/std"]


### PR DESCRIPTION
This is fairly straightforward, adding a `std` feature and relying on `core` and `alloc` where possible. The one thing I am unsure about is having to re-implement ttf-parser's to_string function for Name. It is only a few lines, so it seemed nicer to do it here than pollute ttf-parser's no_std support with `alloc`.