### PR TITLE
Implement Display trait for ID

### DIFF
--- a/examples/find-system-font.rs
+++ b/examples/find-system-font.rs
@@ -29,10 +29,11 @@ fn main() {
             let (src, index) = db.face_source(id).unwrap();
             if let fontdb::Source::File(ref path) = &src {
                 println!(
-                    "Font '{}':{} found in {}ms.",
+                    "Font '{}':{} found in {}ms, fontdb id is '{}'.",
                     path.display(),
                     index,
-                    now.elapsed().as_micros() as f64 / 1000.0
+                    now.elapsed().as_micros() as f64 / 1000.0,
+                    id,
                 );
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ impl ID {
 
 impl core::fmt::Display for ID {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_fmt(format_args!("{}", self.0))
+        write!(f, "{}", self.0)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,11 @@ pub use ttf_parser::Width as Stretch;
 ///
 /// ID overflow will cause a panic, but it's highly unlikely that someone would
 /// load more than 4 billion font faces.
+///
+/// Because the internal representation of ID is private, The `Display` trait
+/// implementation for this type only promise that unequal IDs will be displayed
+/// as different strings, but does not make any guarantees about format or
+/// content of the strings.
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, Debug)]
 pub struct ID(u32);
 
@@ -92,6 +97,12 @@ impl ID {
     #[inline]
     pub fn dummy() -> Self {
         Self(0)
+    }
+}
+
+impl core::fmt::Display for ID {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_fmt(format_args!("{}", self.0))
     }
 }
 


### PR DESCRIPTION
Just like discussed in #38, this PR add Display implementation for ID type, for convenience. And add some document to keep the internal implementation private.