### PR TITLE
m(breaking): Simplify internal storage and lookup mechanisms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["text-processing"]
 [dependencies]
 log = "0.4"
 memmap2 = { version = "0.5", optional = true }
+slab = { version = "0.4.7", default-features = false }
 
 [dependencies.ttf-parser]
 version = "0.18"


### PR DESCRIPTION
This PR replaces the current `Vec` and `next_id`-based storage strategy with the [`Slab`](https://docs.rs/slab/latest/slab/struct.Slab.html) type. `Slab` is similar to the current storage strategy, except that the key corresponds directly to the index in the underlying `Vec`. This means that the lookup process is an `O(1)` process as opposed to an `O(n)` process.

The goal is to replace [this bit of self-referencing code](https://github.com/pop-os/cosmic-text/blob/cb4d5446882da7455d89097e3a35dc0ea566a725/src/font/system/std.rs#L10-L20) in `cosmic-text` so that one can gain access to the underlying `&mut Database`.

The only wrinkle that that `Slab<T>` doesn't directly correspond to an `&[T]`, so the `faces()` function has to be an `impl Iterator<&FaceInfo>` instead of an `&[FaceInfo]`. This is a breaking change.