### PR TITLE
m(breaking): Simplify internal storage and lookup mechanisms, take 3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.42.0
+          - 1.49.0
           - stable
     steps:
     - name: Checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/RazrFalcon/fontdb"
 license = "MIT"
 keywords = ["font", "db", "css", "truetype", "ttf"]
 categories = ["text-processing"]
+rust-version = "1.49"
 
 [dependencies]
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["text-processing"]
 [dependencies]
 log = "0.4"
 memmap2 = { version = "0.5", optional = true }
+slotmap = { version = "1.0.6", default-features = false }
 
 [dependencies.ttf-parser]
 version = "0.18"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Build Status](https://github.com/RazrFalcon/fontdb/workflows/Rust/badge.svg)
 [![Crates.io](https://img.shields.io/crates/v/fontdb.svg)](https://crates.io/crates/fontdb)
 [![Documentation](https://docs.rs/fontdb/badge.svg)](https://docs.rs/fontdb)
-[![Rust 1.42+](https://img.shields.io/badge/rust-1.42+-orange.svg)](https://www.rust-lang.org)
+[![Rust 1.49+](https://img.shields.io/badge/rust-1.49+-orange.svg)](https://www.rust-lang.org)
 
 `fontdb` is a simple, in-memory font database with CSS-like queries.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,12 +72,9 @@ use alloc::{
 pub use ttf_parser::Language;
 pub use ttf_parser::Width as Stretch;
 
-use slotmap::DenseSlotMap;
+use slotmap::SlotMap;
 
 /// A unique per database face ID.
-///
-/// We're using [`KeyData`] internally, which is auto-incremented for each face.
-/// A face removal doesn't decrement the counter.
 ///
 /// Since `Database` is not global/unique, we cannot guarantee that a specific ID
 /// is actually from the same db instance. This is up to the caller.
@@ -152,7 +149,7 @@ impl core::fmt::Display for LoadError {
 /// A font database.
 #[derive(Clone, Debug)]
 pub struct Database {
-    faces: DenseSlotMap<InnerId, FaceInfo>,
+    faces: SlotMap<InnerId, FaceInfo>,
     family_serif: String,
     family_sans_serif: String,
     family_cursive: String,
@@ -173,7 +170,7 @@ impl Database {
     #[inline]
     pub fn new() -> Self {
         Database {
-            faces: DenseSlotMap::with_key(),
+            faces: SlotMap::with_key(),
             family_serif: "Times New Roman".to_string(),
             family_sans_serif: "Arial".to_string(),
             family_cursive: "Comic Sans MS".to_string(),
@@ -455,8 +452,8 @@ impl Database {
     /// Useful when you want to ignore some specific font face(s)
     /// after loading a large directory with fonts.
     /// Or a specific face from a font.
-    pub fn remove_face(&mut self, id: ID) -> bool {
-        self.faces.remove(id.0).is_some()
+    pub fn remove_face(&mut self, id: ID) {
+        self.faces.remove(id.0);
     }
 
     /// Returns `true` if the `Database` contains no font faces.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,9 +72,11 @@ use alloc::{
 pub use ttf_parser::Language;
 pub use ttf_parser::Width as Stretch;
 
+use slotmap::DenseSlotMap;
+
 /// A unique per database face ID.
 ///
-/// We're using `u32` internally, which is auto-incremented for each face.
+/// We're using [`KeyData`] internally, which is auto-incremented for each face.
 /// A face removal doesn't decrement the counter.
 ///
 /// Since `Database` is not global/unique, we cannot guarantee that a specific ID
@@ -87,8 +89,15 @@ pub use ttf_parser::Width as Stretch;
 /// implementation for this type only promise that unequal IDs will be displayed
 /// as different strings, but does not make any guarantees about format or
 /// content of the strings.
+///
+/// [`KeyData`]: https://docs.rs/slotmap/latest/slotmap/struct.KeyData.html
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, Debug)]
-pub struct ID(u32);
+pub struct ID(InnerId);
+
+slotmap::new_key_type! {
+    /// Internal ID type.
+    struct InnerId;
+}
 
 impl ID {
     /// Creates a dummy ID.
@@ -96,13 +105,13 @@ impl ID {
     /// Should be used in tandem with [`Database::push_face_info`].
     #[inline]
     pub fn dummy() -> Self {
-        Self(0)
+        Self(InnerId::from(slotmap::KeyData::from_ffi(core::u64::MAX)))
     }
 }
 
 impl core::fmt::Display for ID {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", (self.0).0.as_ffi())
     }
 }
 
@@ -143,8 +152,7 @@ impl core::fmt::Display for LoadError {
 /// A font database.
 #[derive(Clone, Debug)]
 pub struct Database {
-    next_id: u32,
-    faces: Vec<FaceInfo>,
+    faces: DenseSlotMap<InnerId, FaceInfo>,
     family_serif: String,
     family_sans_serif: String,
     family_cursive: String,
@@ -165,8 +173,7 @@ impl Database {
     #[inline]
     pub fn new() -> Self {
         Database {
-            next_id: 1,
-            faces: Vec::new(),
+            faces: DenseSlotMap::with_key(),
             family_serif: "Times New Roman".to_string(),
             family_sans_serif: "Arial".to_string(),
             family_cursive: "Comic Sans MS".to_string(),
@@ -192,9 +199,8 @@ impl Database {
         source.with_data(|data| {
             let n = ttf_parser::fonts_in_collection(&data).unwrap_or(1);
             for index in 0..n {
-                self.next_id = self.next_id.checked_add(1).unwrap();
-                match parse_face_info(self.next_id, source.clone(), &data, index) {
-                    Ok(info) => self.faces.push(info),
+                match parse_face_info(source.clone(), &data, index) {
+                    Ok(info) => self.push_face_info(info),
                     Err(e) => log::warn!(
                         "Failed to load a font face {} from source cause {}.",
                         index,
@@ -212,9 +218,8 @@ impl Database {
 
         let n = ttf_parser::fonts_in_collection(data).unwrap_or(1);
         for index in 0..n {
-            self.next_id = self.next_id.checked_add(1).unwrap();
-            match parse_face_info(self.next_id, source.clone(), data, index) {
-                Ok(info) => self.faces.push(info),
+            match parse_face_info(source.clone(), data, index) {
+                Ok(info) => self.push_face_info(info),
                 Err(e) => {
                     log::warn!(
                         "Failed to load a font face {} from '{}' cause {}.",
@@ -437,9 +442,10 @@ impl Database {
     ///
     /// The `id` field should be set to [`ID::dummy()`] and will be then overwritten by this method.
     pub fn push_face_info(&mut self, mut info: FaceInfo) {
-        self.next_id = self.next_id.checked_add(1).unwrap();
-        info.id = ID(self.next_id);
-        self.faces.push(info);
+        self.faces.insert_with_key(|k| {
+            info.id = ID(k);
+            info
+        });
     }
 
     /// Removes a font face by `id` from the database.
@@ -450,13 +456,7 @@ impl Database {
     /// after loading a large directory with fonts.
     /// Or a specific face from a font.
     pub fn remove_face(&mut self, id: ID) -> bool {
-        match self.faces.iter().position(|item| item.id == id) {
-            Some(idx) => {
-                self.faces.remove(idx);
-                true
-            }
-            None => false,
-        }
+        self.faces.remove(id.0).is_some()
     }
 
     /// Returns `true` if the `Database` contains no font faces.
@@ -521,11 +521,11 @@ impl Database {
             let candidates: Vec<_> = self
                 .faces
                 .iter()
-                .filter(|face| {
+                .filter_map(|(_, face)| {
                     face.families
                         .iter()
                         .find(|family| family.0 == name)
-                        .is_some()
+                        .map(|_| face)
                 })
                 .collect();
 
@@ -539,12 +539,12 @@ impl Database {
         None
     }
 
-    /// Returns a reference to an internal storage.
+    /// Returns an iterator over the internal storage.
     ///
     /// This can be used for manual font matching.
     #[inline]
-    pub fn faces(&self) -> &[FaceInfo] {
-        &self.faces
+    pub fn faces(&self) -> impl Iterator<Item = &FaceInfo> + '_ {
+        self.faces.iter().map(|(_, info)| info)
     }
 
     /// Selects a `FaceInfo` by `id`.
@@ -552,7 +552,7 @@ impl Database {
     /// Returns `None` if a face with such ID was already removed,
     /// or this ID belong to the other `Database`.
     pub fn face(&self, id: ID) -> Option<&FaceInfo> {
-        self.faces.iter().find(|item| item.id == id)
+        self.faces.get(id.0)
     }
 
     /// Returns font face storage and the face index by `ID`.
@@ -604,7 +604,7 @@ impl Database {
         &mut self,
         id: ID,
     ) -> Option<(std::sync::Arc<dyn AsRef<[u8]> + Send + Sync>, u32)> {
-        let face_info = self.faces.iter().find(|item| item.id == id)?;
+        let face_info = self.faces.get(id.0)?;
         let face_index = face_info.index;
 
         let old_source = face_info.source.clone();
@@ -626,7 +626,7 @@ impl Database {
 
         let shared_source = Source::SharedFile(path.clone(), shared_data.clone());
 
-        self.faces.iter_mut().for_each(|face| {
+        self.faces.iter_mut().for_each(|(_, face)| {
             if matches!(&face.source, Source::File(old_path) if old_path == &path) {
                 face.source = shared_source.clone();
             }
@@ -640,7 +640,7 @@ impl Database {
     /// from a file on disk, then that mapping is closed and the data becomes private to the process again.
     #[cfg(all(feature = "fs", feature = "memmap"))]
     pub fn make_face_data_unshared(&mut self, id: ID) {
-        let face_info = match self.faces.iter().find(|item| item.id == id) {
+        let face_info = match self.faces.get(id.0) {
             Some(face_info) => face_info,
             None => return,
         };
@@ -655,7 +655,7 @@ impl Database {
 
         let new_source = Source::File(shared_path.clone());
 
-        self.faces.iter_mut().for_each(|face| {
+        self.faces.iter_mut().for_each(|(_, face)| {
             if matches!(&face.source, Source::SharedFile(path, ..) if path == &shared_path) {
                 face.source = new_source.clone();
             }
@@ -892,19 +892,14 @@ impl Default for Style {
     }
 }
 
-fn parse_face_info(
-    id: u32,
-    source: Source,
-    data: &[u8],
-    index: u32,
-) -> Result<FaceInfo, LoadError> {
+fn parse_face_info(source: Source, data: &[u8], index: u32) -> Result<FaceInfo, LoadError> {
     let raw_face = ttf_parser::RawFace::parse(data, index).map_err(|_| LoadError::MalformedFont)?;
     let (families, post_script_name) = parse_names(&raw_face).ok_or(LoadError::UnnamedFont)?;
     let (style, weight, stretch) = parse_os2(&raw_face);
     let monospaced = parse_post(&raw_face);
 
     Ok(FaceInfo {
-        id: ID(id),
+        id: ID::dummy(),
         source,
         index,
         families,


### PR DESCRIPTION
As discussed [here](https://github.com/RazrFalcon/fontdb/pull/46#issuecomment-1436027904), this PR uses a `slotmap` to maintain the internal font list such that a font `ID` lookup is `O(1)`.