### PR TITLE
feat: Implement Default for Database

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,12 @@ pub struct Database {
     family_monospace: String,
 }
 
+impl Default for Database {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Database {
     /// Create a new, empty `Database`.
     ///


### PR DESCRIPTION
This PR adds a `Default` implementation for `Database` that just calls `Self::new()`.