### PR TITLE
uses default value when $XDG-CONFIG-HOME is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.vscode
 /target
 Cargo.lock
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 /target
 Cargo.lock
 .DS_Store

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,13 +399,12 @@ impl Database {
                 None
             };
 
-            let read_global = xdg_config_home
-                .map(|p| {
-                    fontconfig
-                        .merge_config(&p.join("fontconfig/fonts.conf"))
-                        .is_err()
-                })
-                .unwrap_or(true);
+            let read_global = match xdg_config_home {
+                Some(p) => fontconfig
+                    .merge_config(&p.join("fontconfig/fonts.conf"))
+                    .is_err(),
+                None => true,
+            };
 
             if read_global {
                 let _ = fontconfig.merge_config(Path::new("/etc/fonts/local.conf"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,7 +403,7 @@ impl Database {
                 .map(|p| {
                     fontconfig
                         .merge_config(&p.join("fontconfig/fonts.conf"))
-                        .is_ok()
+                        .is_err()
                 })
                 .unwrap_or(true);
 


### PR DESCRIPTION
In the real world, there are many systems that do not set `XDG-CONFIG-HOME` variable, and fontconfig will follow the [XDG spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), use a default value of  `$HOME/.config`.

This PR emulates it's behavior. And will fallback to loading the global config file `/etc/fonts/local.conf` if parse user's config failed(e.g. file not exist).