### PR TITLE
Handle downloadable fonts on macOS better

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,22 @@ impl Database {
         {
             self.load_fonts_dir("/Library/Fonts");
             self.load_fonts_dir("/System/Library/Fonts");
-            self.load_fonts_dir("/System/Library/AssetsV2/com_apple_MobileAsset_Font6");
+            // Downloadable fonts, location varies on major macOS releases
+            if let Ok(dir) = std::fs::read_dir("/System/Library/AssetsV2") {
+                for entry in dir {
+                    let entry = match entry {
+                        Ok(entry) => entry,
+                        Err(_) => continue,
+                    };
+                    if entry
+                        .file_name()
+                        .to_string_lossy()
+                        .starts_with("com_apple_MobileAsset_Font")
+                    {
+                        self.load_fonts_dir(entry.path());
+                    }
+                }
+            }
             self.load_fonts_dir("/Network/Library/Fonts");
 
             if let Ok(ref home) = std::env::var("HOME") {


### PR DESCRIPTION
Turns out Apple changes the downloadable fonts location on major OS releases.

```bash
$ ls /System/Library/AssetsV2/ | grep Font
com_apple_MobileAsset_Font6
com_apple_MobileAsset_Font7
```

See also https://yatabashi.github.io/font-availability-checker.html