### PR TITLE
Fix Fontconfig alias matching order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,8 +456,8 @@ impl Database {
         {
             let name = prefer
                 .get(0)
-                .or_else(|| default.get(0))
-                .or_else(|| accept.get(0));
+                .or_else(|| accept.get(0))
+                .or_else(|| default.get(0));
 
             if let Some(name) = name {
                 match alias.to_lowercase().as_str() {


### PR DESCRIPTION
Fontconfig alias matching order should be: <prefer>, <accept>, <default>
according to
https://www.freedesktop.org/software/fontconfig/fontconfig-user.html#alias