### PR TITLE
Add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tinyvec = { version = "1.6.0", features = ["alloc"] }
 
 [dependencies.ttf-parser]
 version = "0.20"
+git = "https://github.com/StratusFearMe21/ttf-parser"
 default-features = false
 features = ["opentype-layout", "apple-layout", "variable-fonts", "glyph-names"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ slotmap = { version = "1.0.6", default-features = false }
 tinyvec = { version = "1.6.0", features = ["alloc"] }
 
 [dependencies.ttf-parser]
-# version = "0.20"
-path = "../ttf-parser"
+version = "0.20"
 default-features = false
 features = ["opentype-layout", "apple-layout", "variable-fonts", "glyph-names"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tinyvec = { version = "1.6.0", features = ["alloc"] }
 [dependencies.ttf-parser]
 version = "0.20"
 git = "https://github.com/StratusFearMe21/ttf-parser"
+branch = "serde"
 default-features = false
 features = ["opentype-layout", "apple-layout", "variable-fonts", "glyph-names"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ tinyvec = { version = "1.6.0", features = ["alloc"] }
 
 [dependencies.ttf-parser]
 version = "0.20"
-path = "../ttf-parser"
 default-features = false
 features = ["opentype-layout", "apple-layout", "variable-fonts", "glyph-names"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ rust-version = "1.60"
 [dependencies]
 log = "0.4"
 memmap2 = { version = "0.9", optional = true }
+serde = { version = "1.0.196", features = ["derive"], default-features = false, optional = true }
 slotmap = { version = "1.0.6", default-features = false }
 tinyvec = { version = "1.6.0", features = ["alloc"] }
 
 [dependencies.ttf-parser]
-version = "0.20"
+# version = "0.20"
+path = "../ttf-parser"
 default-features = false
 features = ["opentype-layout", "apple-layout", "variable-fonts", "glyph-names"]
 
@@ -39,3 +41,4 @@ memmap = ["fs", "memmap2"]
 # Enables minimal fontconfig support on Linux.
 # Must be enabled for NixOS, otherwise no fonts will be loaded.
 fontconfig = ["fontconfig-parser", "fs"]
+serde = ["dep:serde", "slotmap/serde", "ttf-parser/serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tinyvec = { version = "1.6.0", features = ["alloc"] }
 
 [dependencies.ttf-parser]
 version = "0.20"
+path = "../ttf-parser"
 default-features = false
 features = ["opentype-layout", "apple-layout", "variable-fonts", "glyph-names"]
 
@@ -32,7 +33,7 @@ env_logger = { version = "0.10", default-features = false }
 
 [features]
 default = ["std", "fs", "memmap", "fontconfig"]
-std = ["ttf-parser/std"]
+std = ["ttf-parser/std", "serde?/std"]
 # Allows local filesystem interactions.
 fs = ["std"]
 # Allows font files memory mapping, greatly improves performance.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,6 @@ impl core::fmt::Display for ID {
 }
 
 /// A list of possible font loading errors.
-/// https://github.com/RazrFalcon/fontdb
 #[derive(Debug)]
 enum LoadError {
     /// A malformed font.


### PR DESCRIPTION
This PR is actually a group of 3 PRs

- https://github.com/pop-os/cosmic-text/pull/228
- https://github.com/RazrFalcon/fontdb/pull/63
- https://github.com/RazrFalcon/ttf-parser/pull/139

Right now, I'm making a slideshow program which uses `cosmic-text` for shaping and layout. I'd love to be able to serialize my slideshows into a packed serde format, and in order to do that, I need the types in the libraries in these 3 PRs to implement the serde traits. 