### PR TITLE
Return ID in `push_face_info`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,9 @@ impl Database {
         let n = ttf_parser::fonts_in_collection(data).unwrap_or(1);
         for index in 0..n {
             match parse_face_info(source.clone(), data, index) {
-                Ok(info) => self.push_face_info(info),
+                Ok(info) => {
+                    self.push_face_info(info);
+                }
                 Err(e) => {
                     log::warn!(
                         "Failed to load a font face {} from '{}' cause {}.",
@@ -503,11 +505,11 @@ impl Database {
     /// This method doesn't parse the `source` font.
     ///
     /// The `id` field should be set to [`ID::dummy()`] and will be then overwritten by this method.
-    pub fn push_face_info(&mut self, mut info: FaceInfo) {
-        self.faces.insert_with_key(|k| {
+    pub fn push_face_info(&mut self, mut info: FaceInfo) -> ID {
+        ID(self.faces.insert_with_key(|k| {
             info.id = ID(k);
             info
-        });
+        }))
     }
 
     /// Removes a font face by `id` from the database.


### PR DESCRIPTION
This makes `push_face_info` more useful because the callee knows what they pushed and can use it. Especially useful for the [`FontResolver`](https://github.com/RazrFalcon/resvg/pull/769) in usvg.

The two current alternatives for loading and using well-known fonts are:
- `load_font_source`, but it's less convenient (because of font collections) and doesn't allow to override the metadata
- `push_face_info` and then try to figure out the ID somehow with `faces()` or something like that

Notably, the PR is a breaking change like this, but we could also add a new function instead.