### PR TITLE
fix: add support for symlinked files and dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Symlinked files and directories will now be included when loading
+  system fonts.
 
 ## [0.20.0] - 2024-07-02
 ### Changed


### PR DESCRIPTION
This adds support for searching through symlinked files and directories, the path is first canonicalized - which will resolve nested symlinks to the real path. Due to the nature of symlinks it's still possible for an infinitely recursive data structure to arise, or for the same canonical file to be repeated. Both cases are covered by keeping track of which canonical files have already been visited.

These changes are required to correctly support some Nix scenarios, specifically installing fonts through home-manager.