### PR TITLE
Gate find-system-font example behind 'fs' feature

### DIFF
--- a/examples/find-system-font.rs
+++ b/examples/find-system-font.rs
@@ -1,3 +1,7 @@
+#[cfg(not(feature = "fs"))]
+fn main() {}
+
+#[cfg(feature = "fs")]
 fn main() {
     std::env::set_var("RUST_LOG", "fontdb=trace");
     env_logger::init();


### PR DESCRIPTION
Hello. `cargo test --all --no-default-features` fails because the `find-system-font` example cannot compile unless the `fs` feature is enabled:

```
error[E0599]: no method named `load_system_fonts` found for struct `Database` in the current scope
 --> examples/find-system-font.rs:7:8
  |
7 |     db.load_system_fonts();
  |        ^^^^^^^^^^^^^^^^^ method not found in `Database`

error[E0599]: no variant or associated item named `File` found for enum `Source` in the current scope
  --> examples/find-system-font.rs:30:36
   |
30 |             if let fontdb::Source::File(ref path) = &src {
   |                                    ^^^^ variant or associated item not found in `Source`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `fontdb` (example "find-system-font") due to 2 previous errors
```

This PR gates the example behind said feature, so that non-default tests do not fail. Ref: https://sources.debian.org/src/rust-fontdb/0.21.0-1/debian/patches/fix-tests.patch/