### PR TITLE
Fix CI status badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # fontdb
-![Build Status](https://github.com/RazrFalcon/fontdb/workflows/Rust/badge.svg)
+[![Build Status](https://github.com/RazrFalcon/fontdb/actions/workflows/main.yml/badge.svg)](https://github.com/RazrFalcon/fontdb/actions/workflows/main.yml)
 [![Crates.io](https://img.shields.io/crates/v/fontdb.svg)](https://crates.io/crates/fontdb)
 [![Documentation](https://docs.rs/fontdb/badge.svg)](https://docs.rs/fontdb)
 [![Rust 1.60+](https://img.shields.io/badge/rust-1.60+-orange.svg)](https://www.rust-lang.org)


### PR DESCRIPTION
This line was generated on GitHub's interface, so that it:
 - Doesn't consider workflow runs for PRs
 - Links to the workflow instead of to the SVG file