### PR TITLE
Load fonts from Flatpak font directories

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,6 +487,11 @@ impl Database {
         self.load_fonts_dir_impl("/usr/share/fonts/".as_ref(), &mut seen);
         self.load_fonts_dir_impl("/usr/local/share/fonts/".as_ref(), &mut seen);
 
+        // Flatpak font directories
+        self.load_fonts_dir_impl("/run/host/fonts/".as_ref(), &mut seen);
+        self.load_fonts_dir_impl("/run/host/local-fonts/".as_ref(), &mut seen);
+        self.load_fonts_dir_impl("/run/host/user-fonts/".as_ref(), &mut seen);
+
         if let Ok(ref home) = std::env::var("HOME") {
             let home_path = std::path::Path::new(home);
             self.load_fonts_dir_impl(&home_path.join(".fonts"), &mut seen);


### PR DESCRIPTION
Flatpak exposes fonts from the host to the sandbox in three special directories under /run/host. This change loads fonts in those directories if they exist. Fixes #78

See Flatpak's [documentation](https://docs.flatpak.org/en/latest/desktop-integration.html#fonts) for more info.

I'm not sure how to test this. The code is fairly straight-forward, but I'm happy to consider any suggestions for instilling confidence in these changes.