### PR TITLE
Add iOS support to load_system_fonts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ impl Database {
     /// - `serif` - Times New Roman
     /// - `sans-serif` - Arial
     /// - `cursive` - Comic Sans MS
-    /// - `fantasy` - Impact (Papyrus on macOS)
+    /// - `fantasy` - Impact (Papyrus on macOS/iOS)
     /// - `monospace` - Courier New
     #[inline]
     pub fn new() -> Self {
@@ -181,9 +181,9 @@ impl Database {
             family_serif: "Times New Roman".to_string(),
             family_sans_serif: "Arial".to_string(),
             family_cursive: "Comic Sans MS".to_string(),
-            #[cfg(not(target_os = "macos"))]
+            #[cfg(not(any(target_os = "macos", target_os = "ios")))]
             family_fantasy: "Impact".to_string(),
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
             family_fantasy: "Papyrus".to_string(),
             family_monospace: "Courier New".to_string(),
         }
@@ -421,7 +421,7 @@ impl Database {
             }
         }
 
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             let mut seen = Default::default();
             self.load_fonts_dir_impl("/Library/Fonts".as_ref(), &mut seen);
@@ -458,7 +458,7 @@ impl Database {
         }
 
         // Linux.
-        #[cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))]
+        #[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
         {
             #[cfg(feature = "fontconfig")]
             {
@@ -480,7 +480,7 @@ impl Database {
     #[cfg(all(
         unix,
         feature = "fs",
-        not(any(target_os = "macos", target_os = "android"))
+        not(any(target_os = "macos", target_os = "ios", target_os = "android"))
     ))]
     fn load_no_fontconfig(&mut self) {
         let mut seen = Default::default();
@@ -498,7 +498,7 @@ impl Database {
     #[cfg(all(
         unix,
         feature = "fontconfig",
-        not(any(target_os = "macos", target_os = "android"))
+        not(any(target_os = "macos", target_os = "ios", target_os = "android"))
     ))]
     fn load_fontconfig(&mut self) -> bool {
         use std::path::Path;


### PR DESCRIPTION
## Summary

Closes #77 — adds iOS support to `Database::load_system_fonts` by reusing the existing macOS path-scanning logic.

## Why this approach

As discussed in #77 by @Kees-van-Beilen, iOS apps **can** access `/System/Library/Fonts/` from a sandboxed app via the application container's symlink to `/System/Library`. This is explicitly permitted by App Store review guideline 2.5.2 and is the same approach used by many shipping iOS apps. No CoreText FFI dependency is required, and the change keeps fontdb's portable, dependency-free architecture intact.

## Changes

- `load_system_fonts`: extend the macOS `cfg` block to fire on iOS too.
- `family_fantasy`: default to `"Papyrus"` on iOS as well (matches macOS, as the same system fonts are present).
- Linux `cfg` blocks: exclude `target_os = "ios"` so iOS doesn't accidentally fall through to the Linux/fontconfig branch.

## Verification

```
cargo check                                # macOS host: ✓
cargo check --target aarch64-apple-ios     # iOS device: ✓
```