### PR TITLE
Make query by family name case insensitive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,7 +475,6 @@ impl Database {
         }
     }
 
-
     // Linux.
     #[cfg(all(
         unix,
@@ -664,7 +663,11 @@ impl Database {
             let candidates: Vec<_> = self
                 .faces
                 .iter()
-                .filter(|(_, face)| face.families.iter().any(|family| family.0 == name))
+                .filter(|(_, face)| {
+                    face.families
+                        .iter()
+                        .any(|family| family.0.eq_ignore_ascii_case(name))
+                })
                 .map(|(_, info)| info)
                 .collect();
 

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,0 +1,22 @@
+const DEMO_TTF: &[u8] = include_bytes!("./fonts/Tuffy.ttf");
+use std::sync::Arc;
+
+#[test]
+fn query_family_name_case() {
+    env_logger::init();
+    let mut font_db = fontdb::Database::new();
+    let ids = font_db.load_font_source(fontdb::Source::Binary(Arc::new(DEMO_TTF)));
+
+    assert_eq!(ids.len(), 1);
+    let id = ids[0];
+
+    let name_variations = vec!["Tuffy", "tuffy", "TUFFY"];
+    for name in name_variations.iter() {
+        let query = fontdb::Query {
+            families: &[fontdb::Family::Name(name)],
+            ..fontdb::Query::default()
+        };
+        let retrieved_id = font_db.query(&query);
+        assert!(!retrieved_id.is_none() && retrieved_id.unwrap() == id);
+    }
+}


### PR DESCRIPTION
While investigating a SVG text display issue in servo/resvg, I noticed that query does a case-sensitive matching on family name, while it should not according to my read of:
 https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#font-family-casing

My initial problem was unrelated in the end, but I figured it'd still make sense to fix this discrepancy in fontdb (that sounds like a better place to fix than resvg, which is what I'm ultimately interested in).