### PR TITLE
Port fontdb to Fontations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.80.0
+          - 1.85.0
           - stable
     steps:
     - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0
+          - 1.80.0
           - stable
     steps:
     - name: Checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.80"
 [dependencies]
 log = "0.4"
 memmap2 = { version = "0.9", optional = true }
+read-fonts = "0.35.0"
 slotmap = { version = "1.0.6", default-features = false }
 tinyvec = { version = "1.6.0", features = ["alloc"] }
 
@@ -31,7 +32,7 @@ env_logger = { version = "0.10", default-features = false }
 
 [features]
 default = ["std", "fs", "memmap", "fontconfig"]
-std = ["ttf-parser/std"]
+std = ["read-fonts/std"]
 # Allows local filesystem interactions.
 fs = ["std"]
 # Allows font files memory mapping, greatly improves performance.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/RazrFalcon/fontdb"
 license = "MIT"
 keywords = ["font", "db", "css", "truetype", "ttf"]
 categories = ["text-processing"]
-rust-version = "1.80"
+rust-version = "1.85"
 
 [dependencies]
 log = "0.4"
@@ -18,11 +18,6 @@ memmap2 = { version = "0.9", optional = true }
 read-fonts = "0.39.0"
 slotmap = { version = "1.0.6", default-features = false }
 tinyvec = { version = "1.6.0", features = ["alloc"] }
-
-[dependencies.ttf-parser]
-version = "0.25"
-default-features = false
-features = ["opentype-layout", "apple-layout", "variable-fonts", "glyph-names", "no-std-float"]
 
 [target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))'.dependencies]
 fontconfig-parser = { version = "0.5", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.80"
 [dependencies]
 log = "0.4"
 memmap2 = { version = "0.9", optional = true }
-read-fonts = "0.35.0"
+read-fonts = "0.39.0"
 slotmap = { version = "1.0.6", default-features = false }
 tinyvec = { version = "1.6.0", features = ["alloc"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/RazrFalcon/fontdb"
 license = "MIT"
 keywords = ["font", "db", "css", "truetype", "ttf"]
 categories = ["text-processing"]
-rust-version = "1.60"
+rust-version = "1.80"
 
 [dependencies]
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 [dependencies]
 log = "0.4"
 memmap2 = { version = "0.9", optional = true }
-read-fonts = "0.39.0"
+read-fonts = "0.41.0"
 slotmap = { version = "1.0.6", default-features = false }
 tinyvec = { version = "1.6.0", features = ["alloc"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -889,7 +889,7 @@ pub struct FaceInfo {
 /// Stores the whole font and not just a single face.
 #[derive(Clone)]
 pub enum Source {
-    /// A font's raw data, typically backed by a Vec<u8>.
+    /// A font's raw data, typically backed by a `Vec<u8>`.
     Binary(alloc::sync::Arc<dyn AsRef<[u8]> + Sync + Send>),
 
     /// A font's path.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,16 @@ use alloc::{
     vec::Vec,
 };
 
+use read_fonts::{
+    tables::{
+        cmap::PlatformId,
+        name::{Encoding, NameRecord},
+        os2::SelectionFlags,
+    },
+    types::{BigEndian, Fixed, NameId},
+    FileRef, FontData, FontRef, TableProvider as _,
+};
 pub use ttf_parser::Language;
-pub use ttf_parser::Width as Stretch;
 
 use slotmap::SlotMap;
 use tinyvec::TinyVec;
@@ -202,7 +210,15 @@ impl Database {
     /// Will load all font faces in case of a font collection.
     pub fn load_font_source(&mut self, source: Source) -> TinyVec<[ID; 8]> {
         let ids = source.with_data(|data| {
-            let n = ttf_parser::fonts_in_collection(data).unwrap_or(1);
+            let Ok(file) = FileRef::new(data) else {
+                log::warn!("Failed to load a font face");
+                return Default::default();
+            };
+
+            let n = match &file {
+                FileRef::Font(_) => 1,
+                FileRef::Collection(collection_ref) => collection_ref.len(),
+            };
             let mut ids = TinyVec::with_capacity(n as usize);
 
             for index in 0..n {
@@ -233,7 +249,16 @@ impl Database {
     fn load_fonts_from_file(&mut self, path: &std::path::Path, data: &[u8]) {
         let source = Source::File(path.into());
 
-        let n = ttf_parser::fonts_in_collection(data).unwrap_or(1);
+        let Ok(file) = FileRef::new(data) else {
+            log::warn!("Failed to load a font face from '{}'", path.display());
+            return;
+        };
+
+        let n = match &file {
+            FileRef::Font(_) => 1,
+            FileRef::Collection(collection_ref) => collection_ref.len(),
+        };
+
         for index in 0..n {
             match parse_face_info(source.clone(), data, index) {
                 Ok(info) => {
@@ -475,7 +500,6 @@ impl Database {
         }
     }
 
-
     // Linux.
     #[cfg(all(
         unix,
@@ -714,8 +738,9 @@ impl Database {
     ///
     /// ```ignore
     /// let is_variable = db.with_face_data(id, |font_data, face_index| {
-    ///     let font = ttf_parser::Face::from_slice(font_data, face_index).unwrap();
-    ///     font.is_variable()
+    ///     use read_fonts::TableProvider as _;
+    ///     let font = read_fonts::FontRef::from_index(font_data, face_index).unwrap();
+    ///     font.fvar().is_ok()
     /// })?;
     /// ```
     pub fn with_face_data<P, T>(&self, id: ID, p: P) -> Option<T>
@@ -849,7 +874,7 @@ pub struct FaceInfo {
     pub weight: Weight,
 
     /// A font face stretch.
-    pub stretch: Stretch,
+    pub stretch: Width,
 
     /// Indicates that the font face is monospaced.
     pub monospaced: bool,
@@ -940,7 +965,7 @@ pub struct Query<'a> {
     /// Selects a normal, condensed, or expanded face from a font family.
     ///
     /// [font-stretch](https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#font-stretch-prop) in CSS.
-    pub stretch: Stretch,
+    pub stretch: Width,
 
     /// Allows italic or oblique faces to be selected.
     ///
@@ -1013,6 +1038,63 @@ impl Weight {
     pub const BLACK: Weight = Weight(900);
 }
 
+/// A face [width](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass).
+#[allow(missing_docs)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
+pub enum Width {
+    UltraCondensed,
+    ExtraCondensed,
+    Condensed,
+    SemiCondensed,
+    Normal,
+    SemiExpanded,
+    Expanded,
+    ExtraExpanded,
+    UltraExpanded,
+}
+
+impl Width {
+    /// Returns a numeric representation of a width.
+    #[inline]
+    pub fn to_number(self) -> u16 {
+        match self {
+            Width::UltraCondensed => 1,
+            Width::ExtraCondensed => 2,
+            Width::Condensed => 3,
+            Width::SemiCondensed => 4,
+            Width::Normal => 5,
+            Width::SemiExpanded => 6,
+            Width::Expanded => 7,
+            Width::ExtraExpanded => 8,
+            Width::UltraExpanded => 9,
+        }
+    }
+
+    /// Returns a numeric representation of a width.
+    #[inline]
+    pub fn from_number(num: u16) -> Self {
+        match num {
+            1 => Width::UltraCondensed,
+            2 => Width::ExtraCondensed,
+            3 => Width::Condensed,
+            4 => Width::SemiCondensed,
+            5 => Width::Normal,
+            6 => Width::SemiExpanded,
+            7 => Width::Expanded,
+            8 => Width::ExtraExpanded,
+            9 => Width::UltraExpanded,
+            _ => Width::Normal,
+        }
+    }
+}
+
+impl Default for Width {
+    #[inline]
+    fn default() -> Self {
+        Width::Normal
+    }
+}
+
 /// Allows italic or oblique faces to be selected.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum Style {
@@ -1032,10 +1114,10 @@ impl Default for Style {
 }
 
 fn parse_face_info(source: Source, data: &[u8], index: u32) -> Result<FaceInfo, LoadError> {
-    let raw_face = ttf_parser::RawFace::parse(data, index).map_err(|_| LoadError::MalformedFont)?;
-    let (families, post_script_name) = parse_names(&raw_face).ok_or(LoadError::UnnamedFont)?;
-    let (mut style, weight, stretch) = parse_os2(&raw_face);
-    let (monospaced, italic) = parse_post(&raw_face);
+    let font_ref = FontRef::from_index(data, index).map_err(|_| LoadError::MalformedFont)?;
+    let (families, post_script_name) = parse_names(&font_ref).ok_or(LoadError::UnnamedFont)?;
+    let (mut style, weight, stretch) = parse_os2(&font_ref);
+    let (monospaced, italic) = parse_post(&font_ref);
 
     if style == Style::Normal && italic {
         style = Style::Italic;
@@ -1054,16 +1136,19 @@ fn parse_face_info(source: Source, data: &[u8], index: u32) -> Result<FaceInfo, 
     })
 }
 
-fn parse_names(raw_face: &ttf_parser::RawFace) -> Option<(Vec<(String, Language)>, String)> {
-    const NAME_TAG: ttf_parser::Tag = ttf_parser::Tag::from_bytes(b"name");
-    let name_data = raw_face.table(NAME_TAG)?;
-    let name_table = ttf_parser::name::Table::parse(name_data)?;
+fn parse_names(font_ref: &FontRef<'_>) -> Option<(Vec<(String, Language)>, String)> {
+    let data = font_ref.data();
+    let name_table = font_ref.name().ok()?;
 
-    let mut families = collect_families(ttf_parser::name_id::TYPOGRAPHIC_FAMILY, &name_table.names);
+    let mut families = collect_families(
+        NameId::TYPOGRAPHIC_FAMILY_NAME,
+        &name_table.name_record(),
+        data,
+    );
 
     // We have to fallback to Family Name when no Typographic Family Name was set.
     if families.is_empty() {
-        families = collect_families(ttf_parser::name_id::FAMILY, &name_table.names);
+        families = collect_families(NameId::FAMILY_NAME, &name_table.name_record(), data);
     }
 
     // Make English US the first one.
@@ -1083,21 +1168,23 @@ fn parse_names(raw_face: &ttf_parser::RawFace) -> Option<(Vec<(String, Language)
     }
 
     let post_script_name = name_table
-        .names
+        .name_record()
         .into_iter()
-        .find(|name| {
-            name.name_id == ttf_parser::name_id::POST_SCRIPT_NAME && name.is_supported_encoding()
-        })
-        .and_then(|name| name_to_unicode(&name))?;
+        .find(|name| name.name_id() == NameId::POSTSCRIPT_NAME && name.is_supported_encoding())
+        .and_then(|name| name_to_unicode(&name, data))?;
 
     Some((families, post_script_name))
 }
 
-fn collect_families(name_id: u16, names: &ttf_parser::name::Names) -> Vec<(String, Language)> {
+fn collect_families(
+    name_id: NameId,
+    names: &[NameRecord],
+    data: FontData<'_>,
+) -> Vec<(String, Language)> {
     let mut families = Vec::new();
     for name in names.into_iter() {
         if name.name_id == name_id && name.is_unicode() {
-            if let Some(family) = name_to_unicode(&name) {
+            if let Some(family) = name_to_unicode(&name, data) {
                 families.push((family, name.language()));
             }
         }
@@ -1110,7 +1197,7 @@ fn collect_families(name_id: u16, names: &ttf_parser::name::Names) -> Vec<(Strin
     {
         for name in names.into_iter() {
             if name.name_id == name_id && name.is_mac_roman() {
-                if let Some(family) = name_to_unicode(&name) {
+                if let Some(family) = name_to_unicode(&name, data) {
                     families.push((family, name.language()));
                     break;
                 }
@@ -1121,64 +1208,40 @@ fn collect_families(name_id: u16, names: &ttf_parser::name::Names) -> Vec<(Strin
     families
 }
 
-fn name_to_unicode(name: &ttf_parser::name::Name) -> Option<String> {
-    if name.is_unicode() {
-        let mut raw_data: Vec<u16> = Vec::new();
-        for c in ttf_parser::LazyArray16::<u16>::new(name.name) {
-            raw_data.push(c);
-        }
+fn name_to_unicode(name: &NameRecord, data: FontData<'_>) -> Option<String> {
+    name.string(data).ok().map(|name| name.chars().collect())
+}
 
-        String::from_utf16(&raw_data).ok()
-    } else if name.is_mac_roman() {
-        // We support only MacRoman encoding here, which should be enough in most cases.
-        let mut raw_data = Vec::with_capacity(name.name.len());
-        for b in name.name {
-            raw_data.push(MAC_ROMAN[*b as usize]);
-        }
+fn parse_os2(font_ref: &FontRef<'_>) -> (Style, Weight, Width) {
+    let Ok(table) = font_ref.os2() else {
+        return (Style::Normal, Weight::NORMAL, Width::Normal);
+    };
 
-        String::from_utf16(&raw_data).ok()
+    let flags = table.fs_selection();
+    let style = if flags.contains(SelectionFlags::ITALIC) {
+        Style::Italic
+    } else if table.version() >= 4 && flags.contains(SelectionFlags::OBLIQUE) {
+        Style::Oblique
     } else {
-        None
-    }
-}
-
-fn parse_os2(raw_face: &ttf_parser::RawFace) -> (Style, Weight, Stretch) {
-    const OS2_TAG: ttf_parser::Tag = ttf_parser::Tag::from_bytes(b"OS/2");
-    let table = match raw_face
-        .table(OS2_TAG)
-        .and_then(ttf_parser::os2::Table::parse)
-    {
-        Some(table) => table,
-        None => return (Style::Normal, Weight::NORMAL, Stretch::Normal),
+        Style::Normal
     };
 
-    let style = match table.style() {
-        ttf_parser::Style::Normal => Style::Normal,
-        ttf_parser::Style::Italic => Style::Italic,
-        ttf_parser::Style::Oblique => Style::Oblique,
-    };
+    let weight = Weight(table.us_weight_class());
+    let stretch = Width::from_number(table.us_weight_class());
 
-    let weight = table.weight();
-    let stretch = table.width();
-
-    (style, Weight(weight.to_number()), stretch)
+    (style, weight, stretch)
 }
 
-fn parse_post(raw_face: &ttf_parser::RawFace) -> (bool, bool) {
-    // We need just a single value from the `post` table, while ttf-parser will parse all.
-    // Therefore we have a custom parser.
-
-    const POST_TAG: ttf_parser::Tag = ttf_parser::Tag::from_bytes(b"post");
-    let data = match raw_face.table(POST_TAG) {
-        Some(v) => v,
-        None => return (false, false),
+fn parse_post(font_ref: &FontRef<'_>) -> (bool, bool) {
+    let Ok(table) = font_ref.post() else {
+        return (false, false);
     };
 
     // All we care about, it that u32 at offset 12 is non-zero.
-    let monospaced = data.get(12..16) != Some(&[0, 0, 0, 0]);
+    let monospaced = table.is_fixed_pitch() != 0;
 
     // Italic angle as f16.16.
-    let italic = data.get(4..8) != Some(&[0, 0, 0, 0]);
+    let italic = table.italic_angle() != Fixed::from_i32(0);
 
     (monospaced, italic)
 }
@@ -1188,14 +1251,13 @@ trait NameExt {
     fn is_supported_encoding(&self) -> bool;
 }
 
-impl NameExt for ttf_parser::name::Name<'_> {
+impl NameExt for NameRecord {
     #[inline]
     fn is_mac_roman(&self) -> bool {
-        use ttf_parser::PlatformId::Macintosh;
         // https://docs.microsoft.com/en-us/typography/opentype/spec/name#macintosh-encoding-ids-script-manager-codes
         const MACINTOSH_ROMAN_ENCODING_ID: u16 = 0;
-
-        self.platform_id == Macintosh && self.encoding_id == MACINTOSH_ROMAN_ENCODING_ID
+        self.platform_id == (PlatformId::Macintosh as u16)
+            && self.encoding_id == MACINTOSH_ROMAN_ENCODING_ID
     }
 
     #[inline]
@@ -1220,7 +1282,7 @@ fn find_best_match(candidates: &[&FaceInfo], query: &Query) -> Option<usize> {
     let matching_stretch = if matches {
         // Exact match.
         query.stretch
-    } else if query.stretch <= Stretch::Normal {
+    } else if query.stretch <= Width::Normal {
         // Closest stretch, first checking narrower values and then wider values.
         let stretch = matching_set
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -876,7 +876,7 @@ pub struct FaceInfo {
     pub weight: Weight,
 
     /// A font face stretch.
-    pub stretch: Width,
+    pub stretch: Stretch,
 
     /// Indicates that the font face is monospaced.
     pub monospaced: bool,
@@ -967,7 +967,7 @@ pub struct Query<'a> {
     /// Selects a normal, condensed, or expanded face from a font family.
     ///
     /// [font-stretch](https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#font-stretch-prop) in CSS.
-    pub stretch: Width,
+    pub stretch: Stretch,
 
     /// Allows italic or oblique faces to be selected.
     ///
@@ -1043,7 +1043,7 @@ impl Weight {
 /// A face [width](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass).
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
-pub enum Width {
+pub enum Stretch {
     UltraCondensed,
     ExtraCondensed,
     Condensed,
@@ -1055,20 +1055,20 @@ pub enum Width {
     UltraExpanded,
 }
 
-impl Width {
+impl Stretch {
     /// Returns a numeric representation of a width.
     #[inline]
     pub fn to_number(self) -> u16 {
         match self {
-            Width::UltraCondensed => 1,
-            Width::ExtraCondensed => 2,
-            Width::Condensed => 3,
-            Width::SemiCondensed => 4,
-            Width::Normal => 5,
-            Width::SemiExpanded => 6,
-            Width::Expanded => 7,
-            Width::ExtraExpanded => 8,
-            Width::UltraExpanded => 9,
+            Stretch::UltraCondensed => 1,
+            Stretch::ExtraCondensed => 2,
+            Stretch::Condensed => 3,
+            Stretch::SemiCondensed => 4,
+            Stretch::Normal => 5,
+            Stretch::SemiExpanded => 6,
+            Stretch::Expanded => 7,
+            Stretch::ExtraExpanded => 8,
+            Stretch::UltraExpanded => 9,
         }
     }
 
@@ -1076,24 +1076,24 @@ impl Width {
     #[inline]
     pub fn from_number(num: u16) -> Self {
         match num {
-            1 => Width::UltraCondensed,
-            2 => Width::ExtraCondensed,
-            3 => Width::Condensed,
-            4 => Width::SemiCondensed,
-            5 => Width::Normal,
-            6 => Width::SemiExpanded,
-            7 => Width::Expanded,
-            8 => Width::ExtraExpanded,
-            9 => Width::UltraExpanded,
-            _ => Width::Normal,
+            1 => Stretch::UltraCondensed,
+            2 => Stretch::ExtraCondensed,
+            3 => Stretch::Condensed,
+            4 => Stretch::SemiCondensed,
+            5 => Stretch::Normal,
+            6 => Stretch::SemiExpanded,
+            7 => Stretch::Expanded,
+            8 => Stretch::ExtraExpanded,
+            9 => Stretch::UltraExpanded,
+            _ => Stretch::Normal,
         }
     }
 }
 
-impl Default for Width {
+impl Default for Stretch {
     #[inline]
     fn default() -> Self {
-        Width::Normal
+        Stretch::Normal
     }
 }
 
@@ -1194,9 +1194,9 @@ fn collect_families(font: &FontRef<'_>, name_id: StringId) -> Vec<(String, Langu
     families
 }
 
-fn parse_os2(font_ref: &FontRef<'_>) -> (Style, Weight, Width) {
+fn parse_os2(font_ref: &FontRef<'_>) -> (Style, Weight, Stretch) {
     let Ok(table) = font_ref.os2() else {
-        return (Style::Normal, Weight::NORMAL, Width::Normal);
+        return (Style::Normal, Weight::NORMAL, Stretch::Normal);
     };
 
     let flags = table.fs_selection();
@@ -1209,7 +1209,7 @@ fn parse_os2(font_ref: &FontRef<'_>) -> (Style, Weight, Width) {
     };
 
     let weight = Weight(table.us_weight_class());
-    let stretch = Width::from_number(table.us_weight_class());
+    let stretch = Stretch::from_number(table.us_weight_class());
 
     (style, weight, stretch)
 }
@@ -1244,7 +1244,7 @@ fn find_best_match(candidates: &[&FaceInfo], query: &Query) -> Option<usize> {
     let matching_stretch = if matches {
         // Exact match.
         query.stretch
-    } else if query.stretch <= Width::Normal {
+    } else if query.stretch <= Stretch::Normal {
         // Closest stretch, first checking narrower values and then wider values.
         let stretch = matching_set
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,18 +70,23 @@ use alloc::{
 };
 
 use read_fonts::{
-    tables::{
-        cmap::PlatformId,
-        name::{Encoding, NameRecord},
-        os2::SelectionFlags,
-    },
-    types::{BigEndian, Fixed, NameId},
-    FileRef, FontData, FontRef, TableProvider as _,
+    tables::os2::SelectionFlags,
+    types::{Fixed, NameId},
+    FileRef, FontRef, TableProvider as _,
 };
-pub use ttf_parser::Language;
+
+mod string;
+pub use string::{Language, StringId};
+
+#[cfg(feature = "std")]
+/// Generic atomically reference counted shared data
+/// Can be used to abstract over `&'static [u8]`, `Vec<u8>`, and `Mmap`
+pub type SharedData = std::sync::Arc<dyn AsRef<[u8]> + Send + Sync>;
 
 use slotmap::SlotMap;
 use tinyvec::TinyVec;
+
+use crate::string::LocalizedStrings;
 
 /// A unique per database face ID.
 ///
@@ -111,7 +116,7 @@ impl ID {
     /// Should be used in tandem with [`Database::push_face_info`].
     #[inline]
     pub fn dummy() -> Self {
-        Self(InnerId::from(slotmap::KeyData::from_ffi(core::u64::MAX)))
+        Self(InnerId::from(slotmap::KeyData::from_ffi(u64::MAX)))
     }
 }
 
@@ -764,10 +769,7 @@ impl Database {
     /// the data sharing. If the face was previously marked for data sharing, then this function will
     /// return a clone of the existing reference.
     #[cfg(all(feature = "fs", feature = "memmap"))]
-    pub unsafe fn make_shared_face_data(
-        &mut self,
-        id: ID,
-    ) -> Option<(std::sync::Arc<dyn AsRef<[u8]> + Send + Sync>, u32)> {
+    pub unsafe fn make_shared_face_data(&mut self, id: ID) -> Option<(SharedData, u32)> {
         let face_info = self.faces.get(id.0)?;
         let face_index = face_info.index;
 
@@ -1137,79 +1139,59 @@ fn parse_face_info(source: Source, data: &[u8], index: u32) -> Result<FaceInfo, 
 }
 
 fn parse_names(font_ref: &FontRef<'_>) -> Option<(Vec<(String, Language)>, String)> {
-    let data = font_ref.data();
-    let name_table = font_ref.name().ok()?;
-
-    let mut families = collect_families(
-        NameId::TYPOGRAPHIC_FAMILY_NAME,
-        &name_table.name_record(),
-        data,
-    );
+    // Try Typographic Family Name first
+    let mut families = collect_families(font_ref, NameId::TYPOGRAPHIC_FAMILY_NAME);
 
     // We have to fallback to Family Name when no Typographic Family Name was set.
     if families.is_empty() {
-        families = collect_families(NameId::FAMILY_NAME, &name_table.name_record(), data);
+        families = collect_families(font_ref, NameId::FAMILY_NAME);
     }
-
-    // Make English US the first one.
-    if families.len() > 1 {
-        if let Some(index) = families
-            .iter()
-            .position(|f| f.1 == Language::English_UnitedStates)
-        {
-            if index != 0 {
-                families.swap(0, index);
-            }
-        }
-    }
-
     if families.is_empty() {
         return None;
     }
 
-    let post_script_name = name_table
-        .name_record()
-        .into_iter()
-        .find(|name| name.name_id() == NameId::POSTSCRIPT_NAME && name.is_supported_encoding())
-        .and_then(|name| name_to_unicode(&name, data))?;
+    if families.len() > 1 {
+        // Make English US the first one.
+        let mut en_us_idx = None;
+        let mut en_idx = None;
+        for (i, family) in families.iter().enumerate() {
+            match family.1.as_str() {
+                "en-US" => {
+                    en_us_idx = Some(i);
+                    break;
+                }
+                "en" => {
+                    en_idx = Some(i);
+                }
+                _ => continue,
+            };
+        }
+
+        if let Some(index) = en_us_idx.or(en_idx) {
+            families.swap(0, index);
+        }
+    }
+
+    let post_script_name = LocalizedStrings::new(font_ref, StringId::POSTSCRIPT_NAME)
+        .english_or_first()?
+        .to_string();
 
     Some((families, post_script_name))
 }
 
-fn collect_families(
-    name_id: NameId,
-    names: &[NameRecord],
-    data: FontData<'_>,
-) -> Vec<(String, Language)> {
+fn collect_families(font: &FontRef<'_>, name_id: StringId) -> Vec<(String, Language)> {
     let mut families = Vec::new();
-    for name in names.into_iter() {
-        if name.name_id == name_id && name.is_unicode() {
-            if let Some(family) = name_to_unicode(&name, data) {
-                families.push((family, name.language()));
-            }
-        }
-    }
-
-    // If no Unicode English US family name was found then look for English MacRoman as well.
-    if !families
-        .iter()
-        .any(|f| f.1 == Language::English_UnitedStates)
-    {
-        for name in names.into_iter() {
-            if name.name_id == name_id && name.is_mac_roman() {
-                if let Some(family) = name_to_unicode(&name, data) {
-                    families.push((family, name.language()));
-                    break;
-                }
+    for s in LocalizedStrings::new(font, name_id) {
+        let name: String = s.chars().collect();
+        let lang = s.language();
+        if !name.is_empty() {
+            if let Some(lang) = lang {
+                families.push((name, lang));
             }
         }
     }
 
     families
-}
-
-fn name_to_unicode(name: &NameRecord, data: FontData<'_>) -> Option<String> {
-    name.string(data).ok().map(|name| name.chars().collect())
 }
 
 fn parse_os2(font_ref: &FontRef<'_>) -> (Style, Weight, Width) {
@@ -1244,26 +1226,6 @@ fn parse_post(font_ref: &FontRef<'_>) -> (bool, bool) {
     let italic = table.italic_angle() != Fixed::from_i32(0);
 
     (monospaced, italic)
-}
-
-trait NameExt {
-    fn is_mac_roman(&self) -> bool;
-    fn is_supported_encoding(&self) -> bool;
-}
-
-impl NameExt for NameRecord {
-    #[inline]
-    fn is_mac_roman(&self) -> bool {
-        // https://docs.microsoft.com/en-us/typography/opentype/spec/name#macintosh-encoding-ids-script-manager-codes
-        const MACINTOSH_ROMAN_ENCODING_ID: u16 = 0;
-        self.platform_id == (PlatformId::Macintosh as u16)
-            && self.encoding_id == MACINTOSH_ROMAN_ENCODING_ID
-    }
-
-    #[inline]
-    fn is_supported_encoding(&self) -> bool {
-        self.is_unicode() || self.is_mac_roman()
-    }
 }
 
 // https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#font-style-matching
@@ -1402,42 +1364,3 @@ fn find_best_match(candidates: &[&FaceInfo], query: &Query) -> Option<usize> {
     // Return the result.
     matching_set.into_iter().next()
 }
-
-/// Macintosh Roman to UTF-16 encoding table.
-///
-/// https://en.wikipedia.org/wiki/Mac_OS_Roman
-#[rustfmt::skip]
-const MAC_ROMAN: &[u16; 256] = &[
-    0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007,
-    0x0008, 0x0009, 0x000A, 0x000B, 0x000C, 0x000D, 0x000E, 0x000F,
-    0x0010, 0x2318, 0x21E7, 0x2325, 0x2303, 0x0015, 0x0016, 0x0017,
-    0x0018, 0x0019, 0x001A, 0x001B, 0x001C, 0x001D, 0x001E, 0x001F,
-    0x0020, 0x0021, 0x0022, 0x0023, 0x0024, 0x0025, 0x0026, 0x0027,
-    0x0028, 0x0029, 0x002A, 0x002B, 0x002C, 0x002D, 0x002E, 0x002F,
-    0x0030, 0x0031, 0x0032, 0x0033, 0x0034, 0x0035, 0x0036, 0x0037,
-    0x0038, 0x0039, 0x003A, 0x003B, 0x003C, 0x003D, 0x003E, 0x003F,
-    0x0040, 0x0041, 0x0042, 0x0043, 0x0044, 0x0045, 0x0046, 0x0047,
-    0x0048, 0x0049, 0x004A, 0x004B, 0x004C, 0x004D, 0x004E, 0x004F,
-    0x0050, 0x0051, 0x0052, 0x0053, 0x0054, 0x0055, 0x0056, 0x0057,
-    0x0058, 0x0059, 0x005A, 0x005B, 0x005C, 0x005D, 0x005E, 0x005F,
-    0x0060, 0x0061, 0x0062, 0x0063, 0x0064, 0x0065, 0x0066, 0x0067,
-    0x0068, 0x0069, 0x006A, 0x006B, 0x006C, 0x006D, 0x006E, 0x006F,
-    0x0070, 0x0071, 0x0072, 0x0073, 0x0074, 0x0075, 0x0076, 0x0077,
-    0x0078, 0x0079, 0x007A, 0x007B, 0x007C, 0x007D, 0x007E, 0x007F,
-    0x00C4, 0x00C5, 0x00C7, 0x00C9, 0x00D1, 0x00D6, 0x00DC, 0x00E1,
-    0x00E0, 0x00E2, 0x00E4, 0x00E3, 0x00E5, 0x00E7, 0x00E9, 0x00E8,
-    0x00EA, 0x00EB, 0x00ED, 0x00EC, 0x00EE, 0x00EF, 0x00F1, 0x00F3,
-    0x00F2, 0x00F4, 0x00F6, 0x00F5, 0x00FA, 0x00F9, 0x00FB, 0x00FC,
-    0x2020, 0x00B0, 0x00A2, 0x00A3, 0x00A7, 0x2022, 0x00B6, 0x00DF,
-    0x00AE, 0x00A9, 0x2122, 0x00B4, 0x00A8, 0x2260, 0x00C6, 0x00D8,
-    0x221E, 0x00B1, 0x2264, 0x2265, 0x00A5, 0x00B5, 0x2202, 0x2211,
-    0x220F, 0x03C0, 0x222B, 0x00AA, 0x00BA, 0x03A9, 0x00E6, 0x00F8,
-    0x00BF, 0x00A1, 0x00AC, 0x221A, 0x0192, 0x2248, 0x2206, 0x00AB,
-    0x00BB, 0x2026, 0x00A0, 0x00C0, 0x00C3, 0x00D5, 0x0152, 0x0153,
-    0x2013, 0x2014, 0x201C, 0x201D, 0x2018, 0x2019, 0x00F7, 0x25CA,
-    0x00FF, 0x0178, 0x2044, 0x20AC, 0x2039, 0x203A, 0xFB01, 0xFB02,
-    0x2021, 0x00B7, 0x201A, 0x201E, 0x2030, 0x00C2, 0x00CA, 0x00C1,
-    0x00CB, 0x00C8, 0x00CD, 0x00CE, 0x00CF, 0x00CC, 0x00D3, 0x00D4,
-    0xF8FF, 0x00D2, 0x00DA, 0x00DB, 0x00D9, 0x0131, 0x02C6, 0x02DC,
-    0x00AF, 0x02D8, 0x02D9, 0x02DA, 0x00B8, 0x02DD, 0x02DB, 0x02C7,
-];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,20 @@ use read_fonts::{
 };
 
 mod string;
-pub use string::{Language, StringId};
+use string::{Language as FontationsLanguage, StringId};
+
+// Newtype around the Fontations language to keep it out of the public API
+// This allows us to update Fontations versions in patch releases.
+
+/// An owned BCP-47 language identifier for the localized string.
+#[derive(Copy, Clone, Debug)]
+pub struct Language(FontationsLanguage);
+impl Language {
+    /// Returns the BCP-47 language identifier for the language
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
 
 #[cfg(feature = "std")]
 /// Generic atomically reference counted shared data
@@ -1186,7 +1199,7 @@ fn collect_families(font: &FontRef<'_>, name_id: StringId) -> Vec<(String, Langu
         let lang = s.language();
         if !name.is_empty() {
             if let Some(lang) = lang {
-                families.push((name, lang));
+                families.push((name, Language(lang)));
             }
         }
     }

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,0 +1,599 @@
+// This file is vendored from Skrifa to avoid pulling in the whole of Skrifa
+#![allow(dead_code)]
+
+use read_fonts::{
+    tables::name::{CharIter, Name, NameRecord, NameString},
+    FontRef, TableProvider,
+};
+
+use core::fmt;
+
+#[doc(inline)]
+pub use read_fonts::types::NameId as StringId;
+
+/// Iterator over the characters of a string.
+#[derive(Clone)]
+pub struct Chars<'a> {
+    inner: Option<CharIter<'a>>,
+}
+
+impl Iterator for Chars<'_> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.as_mut()?.next()
+    }
+}
+
+/// Iterator over a collection of localized strings for a specific identifier.
+#[derive(Clone)]
+pub struct LocalizedStrings<'a> {
+    name: Option<Name<'a>>,
+    records: core::slice::Iter<'a, NameRecord>,
+    id: StringId,
+}
+
+impl<'a> LocalizedStrings<'a> {
+    /// Creates a new localized string iterator from the given font and string identifier.
+    pub fn new(font: &FontRef<'a>, id: StringId) -> Self {
+        let name = font.name().ok();
+        let records = name
+            .as_ref()
+            .map(|name| name.name_record().iter())
+            .unwrap_or([].iter());
+        Self { name, records, id }
+    }
+
+    /// Returns the informational string identifier for this iterator.
+    pub fn id(&self) -> StringId {
+        self.id
+    }
+
+    /// Returns the best available English string or the first string in the sequence.
+    ///
+    /// This prefers the following languages, in order: "en-US", "en",
+    /// "" (empty, for bare Unicode platform strings which don't have an associated
+    /// language).
+    ///
+    /// If none of these are found, returns the first string, or `None` if the sequence
+    /// is empty.
+    pub fn english_or_first(self) -> Option<LocalizedString<'a>> {
+        let mut best_rank = -1;
+        let mut best_string = None;
+        for (i, string) in self.enumerate() {
+            let rank = match (i, string.language_str()) {
+                (_, Some("en-US")) => return Some(string),
+                (_, Some("en")) => 2,
+                (_, None) => 1,
+                (0, _) => 0,
+                _ => continue,
+            };
+            if rank > best_rank {
+                best_rank = rank;
+                best_string = Some(string);
+            }
+        }
+        best_string
+    }
+}
+
+impl<'a> Iterator for LocalizedStrings<'a> {
+    type Item = LocalizedString<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let name = self.name.as_ref()?;
+        loop {
+            let record = self.records.next()?;
+            if record.name_id() == self.id {
+                return Some(LocalizedString::new(name, record));
+            }
+        }
+    }
+}
+
+impl Default for LocalizedStrings<'_> {
+    fn default() -> Self {
+        Self {
+            name: None,
+            records: [].iter(),
+            id: StringId::default(),
+        }
+    }
+}
+
+/// String containing a name or other font metadata in a specific language.
+#[derive(Clone, Debug)]
+pub struct LocalizedString<'a> {
+    language: Option<Language>,
+    value: Option<NameString<'a>>,
+}
+
+impl<'a> LocalizedString<'a> {
+    pub fn new(name: &Name<'a>, record: &NameRecord) -> Self {
+        let language = Language::new(name, record);
+        let value = record.string(name.string_data()).ok();
+        Self { language, value }
+    }
+
+    pub fn language(&self) -> Option<Language> {
+        self.language
+    }
+
+    /// Returns the BCP-47 language identifier for the localized string.
+    pub fn language_str(&self) -> Option<&str> {
+        self.language.as_ref().map(|language| language.as_str())
+    }
+
+    /// Returns an iterator over the characters of the localized string.
+    pub fn chars(&self) -> Chars<'a> {
+        Chars {
+            inner: self.value.map(|value| value.chars()),
+        }
+    }
+}
+
+impl fmt::Display for LocalizedString<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for ch in self.chars() {
+            ch.fmt(f)?;
+        }
+        Ok(())
+    }
+}
+
+/// This value is chosen arbitrarily to accommodate common language tags that
+/// are almost always <= 11 bytes (LLL-SSSS-RR where L is primary language, S
+/// is script and R is region) and to keep the Language enum at a reasonable
+/// 32 bytes in size.
+const MAX_INLINE_LANGUAGE_LEN: usize = 30;
+
+/// An owned BCP-47 language identifier for the localized string.
+#[derive(Copy, Clone, Debug)]
+pub struct Language {
+    inner: LanguageInner,
+}
+
+impl Language {
+    /// Create a new Language instance from a Name and NameRecord
+    fn new(name: &Name, record: &NameRecord) -> Option<Self> {
+        LanguageInner::new(name, record).map(|inner| Self { inner })
+    }
+
+    /// Returns the BCP-47 language identifier for the language
+    pub fn as_str(&self) -> &str {
+        self.inner.as_str()
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+#[repr(u8)]
+/// Returns the BCP-47 language identifier for the localized string.
+pub enum LanguageInner {
+    Inline {
+        buf: [u8; MAX_INLINE_LANGUAGE_LEN],
+        len: u8,
+    },
+    Static(&'static str),
+}
+
+impl LanguageInner {
+    fn new(name: &Name, record: &NameRecord) -> Option<Self> {
+        let language_id = record.language_id();
+        // For version 1 name tables, prefer language tags:
+        // https://learn.microsoft.com/en-us/typography/opentype/spec/name#naming-table-version-1
+        const BASE_LANGUAGE_TAG_ID: u16 = 0x8000;
+        if name.version() == 1 && language_id >= BASE_LANGUAGE_TAG_ID {
+            let index = (language_id - BASE_LANGUAGE_TAG_ID) as usize;
+            let language_string = name
+                .lang_tag_record()?
+                .get(index)?
+                .lang_tag(name.string_data())
+                .ok()?;
+            Self::from_name_string(&language_string)
+        } else {
+            match record.platform_id() {
+                // We only match Macintosh and Windows language ids.
+                1 | 3 => Self::from_language_id(language_id),
+                _ => None,
+            }
+        }
+    }
+
+    /// Decodes a language tag string into an inline ASCII byte sequence.
+    fn from_name_string(s: &NameString) -> Option<Self> {
+        let mut buf = [0u8; MAX_INLINE_LANGUAGE_LEN];
+        let mut len = 0;
+        for ch in s.chars() {
+            // From "Tags for Identifying Languages" <https://www.rfc-editor.org/rfc/rfc5646.html#page-6>:
+            // "Although [RFC5234] refers to octets, the language tags described in
+            // this document are sequences of characters from the US-ASCII [ISO646]
+            // repertoire"
+            // Therefore we assume that non-ASCII characters signal an invalid language tag.
+            if !ch.is_ascii() || len == MAX_INLINE_LANGUAGE_LEN {
+                return None;
+            }
+            buf[len] = ch as u8;
+            len += 1;
+        }
+        Some(Self::Inline {
+            buf,
+            len: len as u8,
+        })
+    }
+
+    fn from_language_id(language_id: u16) -> Option<Self> {
+        Some(Self::Static(language_id_to_bcp47(language_id)?))
+    }
+
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Inline { buf: data, len } => {
+                let data = &data[..*len as usize];
+                core::str::from_utf8(data).unwrap_or_default()
+            }
+            Self::Static(str) => str,
+        }
+    }
+}
+
+/// Converts an OpenType language identifier to a BCP-47 language tag.
+fn language_id_to_bcp47(language_id: u16) -> Option<&'static str> {
+    match LANGUAGE_ID_TO_BCP47.binary_search_by(|entry| entry.0.cmp(&language_id)) {
+        Ok(ix) => LANGUAGE_ID_TO_BCP47.get(ix).map(|entry| entry.1),
+        _ => None,
+    }
+}
+
+/// Mapping of OpenType name table language identifier to BCP-47 language tag.
+/// Borrowed from Skia: <https://skia.googlesource.com/skia/+/refs/heads/main/src/sfnt/SkOTTable_name.cpp#98>
+const LANGUAGE_ID_TO_BCP47: &[(u16, &str)] = &[
+    /* A mapping from Mac Language Designators to BCP 47 codes.
+     *  The following list was constructed more or less manually.
+     *  Apple now uses BCP 47 (post OSX10.4), so there will be no new entries.
+     */
+    (0, "en"),        //English
+    (1, "fr"),        //French
+    (2, "de"),        //German
+    (3, "it"),        //Italian
+    (4, "nl"),        //Dutch
+    (5, "sv"),        //Swedish
+    (6, "es"),        //Spanish
+    (7, "da"),        //Danish
+    (8, "pt"),        //Portuguese
+    (9, "nb"),        //Norwegian
+    (10, "he"),       //Hebrew
+    (11, "ja"),       //Japanese
+    (12, "ar"),       //Arabic
+    (13, "fi"),       //Finnish
+    (14, "el"),       //Greek
+    (15, "is"),       //Icelandic
+    (16, "mt"),       //Maltese
+    (17, "tr"),       //Turkish
+    (18, "hr"),       //Croatian
+    (19, "zh-Hant"),  //Chinese (Traditional)
+    (20, "ur"),       //Urdu
+    (21, "hi"),       //Hindi
+    (22, "th"),       //Thai
+    (23, "ko"),       //Korean
+    (24, "lt"),       //Lithuanian
+    (25, "pl"),       //Polish
+    (26, "hu"),       //Hungarian
+    (27, "et"),       //Estonian
+    (28, "lv"),       //Latvian
+    (29, "se"),       //Sami
+    (30, "fo"),       //Faroese
+    (31, "fa"),       //Farsi (Persian)
+    (32, "ru"),       //Russian
+    (33, "zh-Hans"),  //Chinese (Simplified)
+    (34, "nl"),       //Dutch
+    (35, "ga"),       //Irish(Gaelic)
+    (36, "sq"),       //Albanian
+    (37, "ro"),       //Romanian
+    (38, "cs"),       //Czech
+    (39, "sk"),       //Slovak
+    (40, "sl"),       //Slovenian
+    (41, "yi"),       //Yiddish
+    (42, "sr"),       //Serbian
+    (43, "mk"),       //Macedonian
+    (44, "bg"),       //Bulgarian
+    (45, "uk"),       //Ukrainian
+    (46, "be"),       //Byelorussian
+    (47, "uz"),       //Uzbek
+    (48, "kk"),       //Kazakh
+    (49, "az-Cyrl"),  //Azerbaijani (Cyrillic)
+    (50, "az-Arab"),  //Azerbaijani (Arabic)
+    (51, "hy"),       //Armenian
+    (52, "ka"),       //Georgian
+    (53, "mo"),       //Moldavian
+    (54, "ky"),       //Kirghiz
+    (55, "tg"),       //Tajiki
+    (56, "tk"),       //Turkmen
+    (57, "mn-Mong"),  //Mongolian (Traditional)
+    (58, "mn-Cyrl"),  //Mongolian (Cyrillic)
+    (59, "ps"),       //Pashto
+    (60, "ku"),       //Kurdish
+    (61, "ks"),       //Kashmiri
+    (62, "sd"),       //Sindhi
+    (63, "bo"),       //Tibetan
+    (64, "ne"),       //Nepali
+    (65, "sa"),       //Sanskrit
+    (66, "mr"),       //Marathi
+    (67, "bn"),       //Bengali
+    (68, "as"),       //Assamese
+    (69, "gu"),       //Gujarati
+    (70, "pa"),       //Punjabi
+    (71, "or"),       //Oriya
+    (72, "ml"),       //Malayalam
+    (73, "kn"),       //Kannada
+    (74, "ta"),       //Tamil
+    (75, "te"),       //Telugu
+    (76, "si"),       //Sinhalese
+    (77, "my"),       //Burmese
+    (78, "km"),       //Khmer
+    (79, "lo"),       //Lao
+    (80, "vi"),       //Vietnamese
+    (81, "id"),       //Indonesian
+    (82, "tl"),       //Tagalog
+    (83, "ms-Latn"),  //Malay (Roman)
+    (84, "ms-Arab"),  //Malay (Arabic)
+    (85, "am"),       //Amharic
+    (86, "ti"),       //Tigrinya
+    (87, "om"),       //Oromo
+    (88, "so"),       //Somali
+    (89, "sw"),       //Swahili
+    (90, "rw"),       //Kinyarwanda/Ruanda
+    (91, "rn"),       //Rundi
+    (92, "ny"),       //Nyanja/Chewa
+    (93, "mg"),       //Malagasy
+    (94, "eo"),       //Esperanto
+    (128, "cy"),      //Welsh
+    (129, "eu"),      //Basque
+    (130, "ca"),      //Catalan
+    (131, "la"),      //Latin
+    (132, "qu"),      //Quechua
+    (133, "gn"),      //Guarani
+    (134, "ay"),      //Aymara
+    (135, "tt"),      //Tatar
+    (136, "ug"),      //Uighur
+    (137, "dz"),      //Dzongkha
+    (138, "jv-Latn"), //Javanese (Roman)
+    (139, "su-Latn"), //Sundanese (Roman)
+    (140, "gl"),      //Galician
+    (141, "af"),      //Afrikaans
+    (142, "br"),      //Breton
+    (143, "iu"),      //Inuktitut
+    (144, "gd"),      //Scottish (Gaelic)
+    (145, "gv"),      //Manx (Gaelic)
+    (146, "ga"),      //Irish (Gaelic with Lenition)
+    (147, "to"),      //Tongan
+    (148, "el"),      //Greek (Polytonic) Note: ISO 15924 does not have an equivalent script name.
+    (149, "kl"),      //Greenlandic
+    (150, "az-Latn"), //Azerbaijani (Roman)
+    (151, "nn"),      //Nynorsk
+    /* A mapping from Windows LCID to BCP 47 codes.
+     *  This list is the sorted, curated output of tools/win_lcid.cpp.
+     *  Note that these are sorted by value for quick binary lookup, and not logically by lsb.
+     *  The 'bare' language ids (e.g. 0x0001 for Arabic) are omitted
+     *  as they do not appear as valid language ids in the OpenType specification.
+     */
+    (0x0401, "ar-SA"),        //Arabic
+    (0x0402, "bg-BG"),        //Bulgarian
+    (0x0403, "ca-ES"),        //Catalan
+    (0x0404, "zh-TW"),        //Chinese (Traditional)
+    (0x0405, "cs-CZ"),        //Czech
+    (0x0406, "da-DK"),        //Danish
+    (0x0407, "de-DE"),        //German
+    (0x0408, "el-GR"),        //Greek
+    (0x0409, "en-US"),        //English
+    (0x040a, "es-ES_tradnl"), //Spanish
+    (0x040b, "fi-FI"),        //Finnish
+    (0x040c, "fr-FR"),        //French
+    (0x040d, "he-IL"),        //Hebrew
+    (0x040d, "he"),           //Hebrew
+    (0x040e, "hu-HU"),        //Hungarian
+    (0x040e, "hu"),           //Hungarian
+    (0x040f, "is-IS"),        //Icelandic
+    (0x0410, "it-IT"),        //Italian
+    (0x0411, "ja-JP"),        //Japanese
+    (0x0412, "ko-KR"),        //Korean
+    (0x0413, "nl-NL"),        //Dutch
+    (0x0414, "nb-NO"),        //Norwegian (Bokmål)
+    (0x0415, "pl-PL"),        //Polish
+    (0x0416, "pt-BR"),        //Portuguese
+    (0x0417, "rm-CH"),        //Romansh
+    (0x0418, "ro-RO"),        //Romanian
+    (0x0419, "ru-RU"),        //Russian
+    (0x041a, "hr-HR"),        //Croatian
+    (0x041b, "sk-SK"),        //Slovak
+    (0x041c, "sq-AL"),        //Albanian
+    (0x041d, "sv-SE"),        //Swedish
+    (0x041e, "th-TH"),        //Thai
+    (0x041f, "tr-TR"),        //Turkish
+    (0x0420, "ur-PK"),        //Urdu
+    (0x0421, "id-ID"),        //Indonesian
+    (0x0422, "uk-UA"),        //Ukrainian
+    (0x0423, "be-BY"),        //Belarusian
+    (0x0424, "sl-SI"),        //Slovenian
+    (0x0425, "et-EE"),        //Estonian
+    (0x0426, "lv-LV"),        //Latvian
+    (0x0427, "lt-LT"),        //Lithuanian
+    (0x0428, "tg-Cyrl-TJ"),   //Tajik (Cyrillic)
+    (0x0429, "fa-IR"),        //Persian
+    (0x042a, "vi-VN"),        //Vietnamese
+    (0x042b, "hy-AM"),        //Armenian
+    (0x042c, "az-Latn-AZ"),   //Azeri (Latin)
+    (0x042d, "eu-ES"),        //Basque
+    (0x042e, "hsb-DE"),       //Upper Sorbian
+    (0x042f, "mk-MK"),        //Macedonian (FYROM)
+    (0x0432, "tn-ZA"),        //Setswana
+    (0x0434, "xh-ZA"),        //isiXhosa
+    (0x0435, "zu-ZA"),        //isiZulu
+    (0x0436, "af-ZA"),        //Afrikaans
+    (0x0437, "ka-GE"),        //Georgian
+    (0x0438, "fo-FO"),        //Faroese
+    (0x0439, "hi-IN"),        //Hindi
+    (0x043a, "mt-MT"),        //Maltese
+    (0x043b, "se-NO"),        //Sami (Northern)
+    (0x043e, "ms-MY"),        //Malay
+    (0x043f, "kk-KZ"),        //Kazakh
+    (0x0440, "ky-KG"),        //Kyrgyz
+    (0x0441, "sw-KE"),        //Kiswahili
+    (0x0442, "tk-TM"),        //Turkmen
+    (0x0443, "uz-Latn-UZ"),   //Uzbek (Latin)
+    (0x0443, "uz"),           //Uzbek
+    (0x0444, "tt-RU"),        //Tatar
+    (0x0445, "bn-IN"),        //Bengali
+    (0x0446, "pa-IN"),        //Punjabi
+    (0x0447, "gu-IN"),        //Gujarati
+    (0x0448, "or-IN"),        //Oriya
+    (0x0449, "ta-IN"),        //Tamil
+    (0x044a, "te-IN"),        //Telugu
+    (0x044b, "kn-IN"),        //Kannada
+    (0x044c, "ml-IN"),        //Malayalam
+    (0x044d, "as-IN"),        //Assamese
+    (0x044e, "mr-IN"),        //Marathi
+    (0x044f, "sa-IN"),        //Sanskrit
+    (0x0450, "mn-Cyrl"),      //Mongolian (Cyrillic)
+    (0x0451, "bo-CN"),        //Tibetan
+    (0x0452, "cy-GB"),        //Welsh
+    (0x0453, "km-KH"),        //Khmer
+    (0x0454, "lo-LA"),        //Lao
+    (0x0456, "gl-ES"),        //Galician
+    (0x0457, "kok-IN"),       //Konkani
+    (0x045a, "syr-SY"),       //Syriac
+    (0x045b, "si-LK"),        //Sinhala
+    (0x045d, "iu-Cans-CA"),   //Inuktitut (Syllabics)
+    (0x045e, "am-ET"),        //Amharic
+    (0x0461, "ne-NP"),        //Nepali
+    (0x0462, "fy-NL"),        //Frisian
+    (0x0463, "ps-AF"),        //Pashto
+    (0x0464, "fil-PH"),       //Filipino
+    (0x0465, "dv-MV"),        //Divehi
+    (0x0468, "ha-Latn-NG"),   //Hausa (Latin)
+    (0x046a, "yo-NG"),        //Yoruba
+    (0x046b, "quz-BO"),       //Quechua
+    (0x046c, "nso-ZA"),       //Sesotho sa Leboa
+    (0x046d, "ba-RU"),        //Bashkir
+    (0x046e, "lb-LU"),        //Luxembourgish
+    (0x046f, "kl-GL"),        //Greenlandic
+    (0x0470, "ig-NG"),        //Igbo
+    (0x0478, "ii-CN"),        //Yi
+    (0x047a, "arn-CL"),       //Mapudungun
+    (0x047c, "moh-CA"),       //Mohawk
+    (0x047e, "br-FR"),        //Breton
+    (0x0480, "ug-CN"),        //Uyghur
+    (0x0481, "mi-NZ"),        //Maori
+    (0x0482, "oc-FR"),        //Occitan
+    (0x0483, "co-FR"),        //Corsican
+    (0x0484, "gsw-FR"),       //Alsatian
+    (0x0485, "sah-RU"),       //Yakut
+    (0x0486, "qut-GT"),       //K'iche
+    (0x0487, "rw-RW"),        //Kinyarwanda
+    (0x0488, "wo-SN"),        //Wolof
+    (0x048c, "prs-AF"),       //Dari
+    (0x0491, "gd-GB"),        //Scottish Gaelic
+    (0x0801, "ar-IQ"),        //Arabic
+    (0x0804, "zh-Hans"),      //Chinese (Simplified)
+    (0x0807, "de-CH"),        //German
+    (0x0809, "en-GB"),        //English
+    (0x080a, "es-MX"),        //Spanish
+    (0x080c, "fr-BE"),        //French
+    (0x0810, "it-CH"),        //Italian
+    (0x0813, "nl-BE"),        //Dutch
+    (0x0814, "nn-NO"),        //Norwegian (Nynorsk)
+    (0x0816, "pt-PT"),        //Portuguese
+    (0x081a, "sr-Latn-CS"),   //Serbian (Latin)
+    (0x081d, "sv-FI"),        //Swedish
+    (0x082c, "az-Cyrl-AZ"),   //Azeri (Cyrillic)
+    (0x082e, "dsb-DE"),       //Lower Sorbian
+    (0x082e, "dsb"),          //Lower Sorbian
+    (0x083b, "se-SE"),        //Sami (Northern)
+    (0x083c, "ga-IE"),        //Irish
+    (0x083e, "ms-BN"),        //Malay
+    (0x0843, "uz-Cyrl-UZ"),   //Uzbek (Cyrillic)
+    (0x0845, "bn-BD"),        //Bengali
+    (0x0850, "mn-Mong-CN"),   //Mongolian (Traditional Mongolian)
+    (0x085d, "iu-Latn-CA"),   //Inuktitut (Latin)
+    (0x085f, "tzm-Latn-DZ"),  //Tamazight (Latin)
+    (0x086b, "quz-EC"),       //Quechua
+    (0x0c01, "ar-EG"),        //Arabic
+    (0x0c04, "zh-Hant"),      //Chinese (Traditional)
+    (0x0c07, "de-AT"),        //German
+    (0x0c09, "en-AU"),        //English
+    (0x0c0a, "es-ES"),        //Spanish
+    (0x0c0c, "fr-CA"),        //French
+    (0x0c1a, "sr-Cyrl-CS"),   //Serbian (Cyrillic)
+    (0x0c3b, "se-FI"),        //Sami (Northern)
+    (0x0c6b, "quz-PE"),       //Quechua
+    (0x1001, "ar-LY"),        //Arabic
+    (0x1004, "zh-SG"),        //Chinese (Simplified)
+    (0x1007, "de-LU"),        //German
+    (0x1009, "en-CA"),        //English
+    (0x100a, "es-GT"),        //Spanish
+    (0x100c, "fr-CH"),        //French
+    (0x101a, "hr-BA"),        //Croatian (Latin)
+    (0x103b, "smj-NO"),       //Sami (Lule)
+    (0x1401, "ar-DZ"),        //Arabic
+    (0x1404, "zh-MO"),        //Chinese (Traditional)
+    (0x1407, "de-LI"),        //German
+    (0x1409, "en-NZ"),        //English
+    (0x140a, "es-CR"),        //Spanish
+    (0x140c, "fr-LU"),        //French
+    (0x141a, "bs-Latn-BA"),   //Bosnian (Latin)
+    (0x141a, "bs"),           //Bosnian
+    (0x143b, "smj-SE"),       //Sami (Lule)
+    (0x143b, "smj"),          //Sami (Lule)
+    (0x1801, "ar-MA"),        //Arabic
+    (0x1809, "en-IE"),        //English
+    (0x180a, "es-PA"),        //Spanish
+    (0x180c, "fr-MC"),        //French
+    (0x181a, "sr-Latn-BA"),   //Serbian (Latin)
+    (0x183b, "sma-NO"),       //Sami (Southern)
+    (0x1c01, "ar-TN"),        //Arabic
+    (0x1c09, "en-ZA"),        //English
+    (0x1c0a, "es-DO"),        //Spanish
+    (0x1c1a, "sr-Cyrl-BA"),   //Serbian (Cyrillic)
+    (0x1c3b, "sma-SE"),       //Sami (Southern)
+    (0x1c3b, "sma"),          //Sami (Southern)
+    (0x2001, "ar-OM"),        //Arabic
+    (0x2009, "en-JM"),        //English
+    (0x200a, "es-VE"),        //Spanish
+    (0x201a, "bs-Cyrl-BA"),   //Bosnian (Cyrillic)
+    (0x201a, "bs-Cyrl"),      //Bosnian (Cyrillic)
+    (0x203b, "sms-FI"),       //Sami (Skolt)
+    (0x203b, "sms"),          //Sami (Skolt)
+    (0x2401, "ar-YE"),        //Arabic
+    (0x2409, "en-029"),       //English
+    (0x240a, "es-CO"),        //Spanish
+    (0x241a, "sr-Latn-RS"),   //Serbian (Latin)
+    (0x243b, "smn-FI"),       //Sami (Inari)
+    (0x2801, "ar-SY"),        //Arabic
+    (0x2809, "en-BZ"),        //English
+    (0x280a, "es-PE"),        //Spanish
+    (0x281a, "sr-Cyrl-RS"),   //Serbian (Cyrillic)
+    (0x2c01, "ar-JO"),        //Arabic
+    (0x2c09, "en-TT"),        //English
+    (0x2c0a, "es-AR"),        //Spanish
+    (0x2c1a, "sr-Latn-ME"),   //Serbian (Latin)
+    (0x3001, "ar-LB"),        //Arabic
+    (0x3009, "en-ZW"),        //English
+    (0x300a, "es-EC"),        //Spanish
+    (0x301a, "sr-Cyrl-ME"),   //Serbian (Cyrillic)
+    (0x3401, "ar-KW"),        //Arabic
+    (0x3409, "en-PH"),        //English
+    (0x340a, "es-CL"),        //Spanish
+    (0x3801, "ar-AE"),        //Arabic
+    (0x380a, "es-UY"),        //Spanish
+    (0x3c01, "ar-BH"),        //Arabic
+    (0x3c0a, "es-PY"),        //Spanish
+    (0x4001, "ar-QA"),        //Arabic
+    (0x4009, "en-IN"),        //English
+    (0x400a, "es-BO"),        //Spanish
+    (0x4409, "en-MY"),        //English
+    (0x440a, "es-SV"),        //Spanish
+    (0x4809, "en-SG"),        //English
+    (0x480a, "es-HN"),        //Spanish
+    (0x4c0a, "es-NI"),        //Spanish
+    (0x500a, "es-PR"),        //Spanish
+    (0x540a, "es-US"),        //Spanish
+];


### PR DESCRIPTION
Ports `fontdb` from `ttf-parser` to `read-fonts`

- Fixes https://github.com/RazrFalcon/fontdb/issues/90

`string.rs` is vendored from `skrifa` and can be removed if that functionality is moved to `read-fonts`.

This defines the types that were previously re-exported from `ttf-parser` (`Stretch` and `Language`) as custom types in this crate (a newtype in the case of Language) which means that the underlying font library is now a private dependency.