### PR TITLE
Bump MSRV to 1.71

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0
+          - 1.71.0
           - stable
     steps:
     - name: Checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/RazrFalcon/fontdb"
 license = "MIT"
 keywords = ["font", "db", "css", "truetype", "ttf"]
 categories = ["text-processing"]
-rust-version = "1.60"
+rust-version = "1.71"
 
 [dependencies]
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://github.com/RazrFalcon/fontdb/actions/workflows/main.yml/badge.svg)](https://github.com/RazrFalcon/fontdb/actions/workflows/main.yml)
 [![Crates.io](https://img.shields.io/crates/v/fontdb.svg)](https://crates.io/crates/fontdb)
 [![Documentation](https://docs.rs/fontdb/badge.svg)](https://docs.rs/fontdb)
-[![Rust 1.60+](https://img.shields.io/badge/rust-1.60+-orange.svg)](https://www.rust-lang.org)
+[![Rust 1.71+](https://img.shields.io/badge/rust-1.71+-orange.svg)](https://www.rust-lang.org)
 
 `fontdb` is a simple, in-memory font database with CSS-like queries.
 


### PR DESCRIPTION
This is now required by the `log` crate.